### PR TITLE
Add Shortcuts and external event integration

### DIFF
--- a/Geko/AppShortcuts.swift
+++ b/Geko/AppShortcuts.swift
@@ -1,0 +1,33 @@
+//
+//  AppShortcuts.swift
+//  Geko
+//
+//  Exposes Geko intents to the Shortcuts app, Siri, and Spotlight.
+//
+
+import AppIntents
+import GekoShared
+
+struct GekoShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: CompleteHabitIntent(),
+            phrases: [
+                "Complete \(.applicationName) habit",
+                "Log habit in \(.applicationName)",
+                "Mark habit done in \(.applicationName)"
+            ],
+            shortTitle: "Complete Habit",
+            systemImageName: "checkmark.circle"
+        )
+        AppShortcut(
+            intent: ToggleHabitIntent(),
+            phrases: [
+                "Toggle \(.applicationName) habit",
+                "Toggle habit in \(.applicationName)"
+            ],
+            shortTitle: "Toggle Habit",
+            systemImageName: "arrow.uturn.backward.circle"
+        )
+    }
+}

--- a/Geko/ContentView.swift
+++ b/Geko/ContentView.swift
@@ -122,7 +122,9 @@ struct ContentView: View {
                 .onOpenURL { url in
                     if url.scheme == "geko" && url.host == "paywall" {
                         showingPaywall = true
+                        return
                     }
+                    _ = URLSchemeHandler.handle(url)
                 }
                 .sheet(item: $habitToEdit) { habit in
                     EditHabitView(habit: habit)

--- a/Geko/URLSchemeHandler.swift
+++ b/Geko/URLSchemeHandler.swift
@@ -1,0 +1,128 @@
+//
+//  URLSchemeHandler.swift
+//  Geko
+//
+//  Handles geko:// URLs for external app integration (complete, toggle, x-callback-url).
+//
+
+import SwiftUI
+import SwiftData
+import WidgetKit
+import GekoShared
+
+enum URLSchemeHandler {
+    /// Handles geko:// URLs. Returns true if the URL was handled.
+    @MainActor
+    static func handle(_ url: URL) -> Bool {
+        guard url.scheme == "geko" else { return false }
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        var queryItems: [String: String] = [:]
+        for item in components?.queryItems ?? [] {
+            if let value = item.value {
+                queryItems[item.name] = value
+            }
+        }
+
+        let habitName = queryItems["habit"]?.removingPercentEncoding ?? ""
+        let xSuccess = queryItems["x-success"].flatMap { URL(string: $0) }
+        let xError = queryItems["x-error"].flatMap { URL(string: $0) }
+        let isXCallback = url.host == "x-callback-url"
+
+        func openCallback(_ urlToOpen: URL?) {
+            guard let urlToOpen else { return }
+            UIApplication.shared.open(urlToOpen)
+        }
+
+        // Determine action from host or path (for x-callback-url)
+        let action: String
+        if isXCallback {
+            let path = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            action = path.isEmpty ? "complete" : path
+        } else {
+            action = url.host ?? "complete"
+        }
+
+        switch action.lowercased() {
+        case "paywall":
+            return false // Let ContentView handle paywall
+        case "complete":
+            let success = performComplete(habitName: habitName)
+            if isXCallback {
+                openCallback(success ? xSuccess : xError)
+            }
+            return true
+        case "toggle":
+            let success = performToggle(habitName: habitName)
+            if isXCallback {
+                openCallback(success ? xSuccess : xError)
+            }
+            return true
+        default:
+            return false
+        }
+    }
+
+    @MainActor
+    private static func performComplete(habitName: String) -> Bool {
+        guard !habitName.isEmpty else { return false }
+        let container = SharedDataContainer.shared.modelContainer
+        let context = container.mainContext
+
+        let predicate = #Predicate<Habit> { h in h.name == habitName }
+        let descriptor = FetchDescriptor<Habit>(predicate: predicate)
+
+        guard let habits = try? context.fetch(descriptor),
+              let habit = habits.first else {
+            return false
+        }
+
+        habit.incrementCompletion()
+        try? context.save()
+
+        SyncManager.shared.syncHabitCompletion(
+            habitName: habit.name,
+            date: Date(),
+            isCompleted: habit.isCompleted(),
+            completionCount: habit.completionCount()
+        )
+        WidgetCenter.shared.reloadAllTimelines()
+        return true
+    }
+
+    @MainActor
+    private static func performToggle(habitName: String) -> Bool {
+        guard !habitName.isEmpty else { return false }
+        let container = SharedDataContainer.shared.modelContainer
+        let context = container.mainContext
+
+        let predicate = #Predicate<Habit> { h in h.name == habitName }
+        let descriptor = FetchDescriptor<Habit>(predicate: predicate)
+
+        guard let habits = try? context.fetch(descriptor),
+              let habit = habits.first else {
+            return false
+        }
+
+        if habit.isCompleted() {
+            habit.resetCompletion()
+        } else {
+            if habit.dailyTarget > 1 {
+                habit.incrementCompletion()
+            } else {
+                habit.toggleCompleted()
+            }
+        }
+
+        try? context.save()
+
+        SyncManager.shared.syncHabitCompletion(
+            habitName: habit.name,
+            date: Date(),
+            isCompleted: habit.isCompleted(),
+            completionCount: habit.completionCount()
+        )
+        WidgetCenter.shared.reloadAllTimelines()
+        return true
+    }
+}

--- a/GekoShared/AppIntents.swift
+++ b/GekoShared/AppIntents.swift
@@ -1,0 +1,193 @@
+//
+//  AppIntents.swift
+//  GekoShared
+//
+//  Shared App Intents for Shortcuts, widgets, and external integrations.
+//
+
+import AppIntents
+import SwiftData
+import WidgetKit
+
+// MARK: - Habit Entity
+
+public struct HabitEntity: AppEntity {
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation = TypeDisplayRepresentation(name: "Habit")
+    public static var defaultQuery = HabitQuery()
+
+    public var id: String
+    public var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)", subtitle: "\(emoji)")
+    }
+
+    public var name: String
+    public var emoji: String
+
+    public init(id: String, name: String, emoji: String) {
+        self.id = id
+        self.name = name
+        self.emoji = emoji
+    }
+}
+
+// MARK: - Habit Query
+
+public struct HabitQuery: EntityQuery {
+    public init() {}
+
+    public func entities(for identifiers: [HabitEntity.ID]) async throws -> [HabitEntity] {
+        let habits = await loadAllHabits()
+        return habits.filter { identifiers.contains($0.id) }
+    }
+
+    public func suggestedEntities() async throws -> [HabitEntity] {
+        return await loadAllHabits()
+    }
+
+    public func defaultResult() async -> HabitEntity? {
+        let habits = await loadAllHabits()
+        return habits.first
+    }
+
+    private func loadAllHabits() async -> [HabitEntity] {
+        do {
+            let container = SharedDataContainer.shared.modelContainer
+            let context = await container.mainContext
+            let fetchDescriptor = FetchDescriptor<Habit>()
+            let habits = try context.fetch(fetchDescriptor)
+
+            if !habits.isEmpty {
+                return habits.map { habit in
+                    HabitEntity(
+                        id: habit.name,
+                        name: habit.name,
+                        emoji: habit.emoji
+                    )
+                }
+            }
+        } catch {
+            print("Failed to load habits from shared SwiftData: \(error)")
+        }
+
+        return [
+            HabitEntity(id: "Exercise", name: "Exercise", emoji: "💪"),
+            HabitEntity(id: "Reading", name: "Reading", emoji: "📚"),
+            HabitEntity(id: "Meditation", name: "Meditation", emoji: "🧘"),
+            HabitEntity(id: "Water", name: "Drink Water", emoji: "💧"),
+            HabitEntity(id: "Sleep", name: "Good Sleep", emoji: "😴")
+        ]
+    }
+}
+
+// MARK: - Complete Habit Intent
+
+public struct CompleteHabitIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Complete Habit"
+    public static var description = IntentDescription("Mark habit as completed for today")
+
+    @Parameter(title: "Habit")
+    public var habit: HabitEntity?
+
+    public init() {}
+
+    public init(habit: HabitEntity?) {
+        self.habit = habit
+    }
+
+    public init(habitName: String) {
+        self.habit = HabitEntity(id: habitName, name: habitName, emoji: "✅")
+    }
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let habitName = habit?.name ?? ""
+        guard !habitName.isEmpty else {
+            return .result(value: "No habit selected")
+        }
+
+        let sharedModelContainer = SharedDataContainer.shared.modelContainer
+        let context = sharedModelContainer.mainContext
+
+        let predicate = #Predicate<Habit> { h in h.name == habitName }
+        let fetchDescriptor = FetchDescriptor<Habit>(predicate: predicate)
+
+        guard let habits = try? context.fetch(fetchDescriptor),
+              let habitModel = habits.first else {
+            return .result(value: "Habit '\(habitName)' not found")
+        }
+
+        habitModel.incrementCompletion()
+        try? context.save()
+
+        SyncManager.shared.syncHabitCompletion(
+            habitName: habitModel.name,
+            date: Date(),
+            isCompleted: habitModel.isCompleted(),
+            completionCount: habitModel.completionCount()
+        )
+        WidgetCenter.shared.reloadAllTimelines()
+
+        return .result(value: "\(habitName) completed")
+    }
+}
+
+// MARK: - Toggle Habit Intent
+
+public struct ToggleHabitIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Toggle Habit"
+    public static var description = IntentDescription("Toggle habit completion - reset if completed, increment if not")
+
+    @Parameter(title: "Habit")
+    public var habit: HabitEntity?
+
+    public init() {}
+
+    public init(habit: HabitEntity?) {
+        self.habit = habit
+    }
+
+    public init(habitName: String) {
+        self.habit = HabitEntity(id: habitName, name: habitName, emoji: "✅")
+    }
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let habitName = habit?.name ?? ""
+        guard !habitName.isEmpty else {
+            return .result(value: "No habit selected")
+        }
+
+        let sharedModelContainer = SharedDataContainer.shared.modelContainer
+        let context = sharedModelContainer.mainContext
+
+        let predicate = #Predicate<Habit> { h in h.name == habitName }
+        let fetchDescriptor = FetchDescriptor<Habit>(predicate: predicate)
+
+        guard let habits = try? context.fetch(fetchDescriptor),
+              let habitModel = habits.first else {
+            return .result(value: "Habit '\(habitName)' not found")
+        }
+
+        if habitModel.isCompleted() {
+            habitModel.resetCompletion()
+        } else {
+            if habitModel.dailyTarget > 1 {
+                habitModel.incrementCompletion()
+            } else {
+                habitModel.toggleCompleted()
+            }
+        }
+
+        try? context.save()
+
+        SyncManager.shared.syncHabitCompletion(
+            habitName: habitModel.name,
+            date: Date(),
+            isCompleted: habitModel.isCompleted(),
+            completionCount: habitModel.completionCount()
+        )
+        WidgetCenter.shared.reloadAllTimelines()
+
+        return .result(value: "\(habitName) toggled")
+    }
+}

--- a/GekoWidgets/AppIntent.swift
+++ b/GekoWidgets/AppIntent.swift
@@ -4,74 +4,13 @@
 //
 //  Created by Irenews on 9/20/25.
 //
+//  Widget configuration intent. HabitEntity, HabitQuery, CompleteHabitIntent,
+//  and ToggleHabitIntent are defined in GekoShared/AppIntents.swift.
+//
 
 import WidgetKit
 import AppIntents
-import SwiftData
 import GekoShared
-
-// Entity representing a habit for selection
-struct HabitEntity: AppEntity {
-    static var typeDisplayRepresentation: TypeDisplayRepresentation = TypeDisplayRepresentation(name: "Habit")
-    static var defaultQuery = HabitQuery()
-    
-    var id: String
-    var displayRepresentation: DisplayRepresentation {
-        // Most SDKs accept String directly thanks to ExpressibleByStringInterpolation
-        DisplayRepresentation(title: "\(name)", subtitle: "\(emoji)")
-    }
-    
-    var name: String
-    var emoji: String
-}
-
-// Query to fetch available habits
-struct HabitQuery: EntityQuery {
-    func entities(for identifiers: [HabitEntity.ID]) async throws -> [HabitEntity] {
-        let habits = await loadAllHabits()
-        return habits.filter { identifiers.contains($0.id) }
-    }
-    
-    func suggestedEntities() async throws -> [HabitEntity] {
-        return await loadAllHabits()
-    }
-    
-    func defaultResult() async -> HabitEntity? {
-        let habits = await loadAllHabits()
-        return habits.first
-    }
-    
-    private func loadAllHabits() async -> [HabitEntity] {
-        // Try to load from shared SwiftData container first
-        do {
-            let container = SharedDataContainer.shared.modelContainer
-            let context = await container.mainContext
-            let fetchDescriptor = FetchDescriptor<Habit>()
-            let habits = try context.fetch(fetchDescriptor)
-            
-            if !habits.isEmpty {
-                return habits.map { habit in
-                    HabitEntity(
-                        id: habit.name, // Using name as ID for simplicity
-                        name: habit.name,
-                        emoji: habit.emoji
-                    )
-                }
-            }
-        } catch {
-            print("Failed to load habits from shared SwiftData: \(error)")
-        }
-        
-        // Fallback to sample habits if SwiftData is empty or fails
-        return [
-            HabitEntity(id: "Exercise", name: "Exercise", emoji: "💪"),
-            HabitEntity(id: "Reading", name: "Reading", emoji: "📚"),
-            HabitEntity(id: "Meditation", name: "Meditation", emoji: "🧘"),
-            HabitEntity(id: "Water", name: "Drink Water", emoji: "💧"),
-            HabitEntity(id: "Sleep", name: "Good Sleep", emoji: "😴")
-        ]
-    }
-}
 
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource { "Select Habit" }
@@ -79,101 +18,9 @@ struct ConfigurationAppIntent: WidgetConfigurationIntent {
 
     @Parameter(title: "Habit", description: "The habit to track in this widget")
     var selectedHabit: HabitEntity?
-    
+
     // Legacy property for backwards compatibility
     var habitName: String {
         return selectedHabit?.name ?? "Water"
-    }
-}
-
-// Intent for completing a habit from the widget
-struct CompleteHabitIntent: AppIntent {
-    static var title: LocalizedStringResource = "Complete Habit"
-    static var description = IntentDescription("Mark habit as completed for today")
-    
-    @Parameter(title: "Habit Name")
-    var habitName: String
-    
-    init() {}
-    
-    init(habitName: String) {
-        self.habitName = habitName
-    }
-    
-    @MainActor
-    func perform() async throws -> some IntentResult {
-        // Get the shared model context
-        let sharedModelContainer = SharedDataContainer.shared.modelContainer
-        let context = sharedModelContainer.mainContext
-        
-        // Find the habit by name
-        let predicate = #Predicate<Habit> { habit in
-            habit.name == habitName
-        }
-        let fetchDescriptor = FetchDescriptor<Habit>(predicate: predicate)
-        
-        guard let habits = try? context.fetch(fetchDescriptor),
-              let habit = habits.first else {
-            return .result()
-        }
-        
-        // Increment completion
-        habit.incrementCompletion()
-        
-        // Save the context
-        try? context.save()
-        
-        return .result()
-    }
-}
-
-// Intent for toggling habit completion (reset if completed, increment if not)
-struct ToggleHabitIntent: AppIntent {
-    static var title: LocalizedStringResource = "Toggle Habit"
-    static var description = IntentDescription("Toggle habit completion - reset if completed, increment if not")
-    
-    @Parameter(title: "Habit Name")
-    var habitName: String
-    
-    init() {}
-    
-    init(habitName: String) {
-        self.habitName = habitName
-    }
-    
-    @MainActor
-    func perform() async throws -> some IntentResult {
-        // Get the shared model context
-        let sharedModelContainer = SharedDataContainer.shared.modelContainer
-        let context = sharedModelContainer.mainContext
-        
-        // Find the habit by name
-        let predicate = #Predicate<Habit> { habit in
-            habit.name == habitName
-        }
-        let fetchDescriptor = FetchDescriptor<Habit>(predicate: predicate)
-        
-        guard let habits = try? context.fetch(fetchDescriptor),
-              let habit = habits.first else {
-            return .result()
-        }
-        
-        // Check if habit is completed and toggle accordingly
-        if habit.isCompleted() {
-            // If already completed, reset to 0
-            habit.resetCompletion()
-        } else {
-            // If not completed, increment by 1
-            if habit.dailyTarget > 1 {
-                habit.incrementCompletion()
-            } else {
-                habit.toggleCompleted()
-            }
-        }
-        
-        // Save the context
-        try? context.save()
-        
-        return .result()
     }
 }


### PR DESCRIPTION
## Summary

Adds App Shortcuts for Siri/Shortcuts/Spotlight integration and extends the URL scheme so other apps can register habit completions.

## Changes

- **GekoShared/AppIntents.swift**: HabitEntity, HabitQuery, CompleteHabitIntent, ToggleHabitIntent with SyncManager and WidgetCenter calls
- **Geko/AppShortcuts.swift**: AppShortcutsProvider exposing intents to Shortcuts, Siri, Spotlight
- **Geko/URLSchemeHandler.swift**: Handles `geko://complete`, `geko://toggle`, and x-callback-url
- **ContentView**: Extended onOpenURL for complete/toggle URLs
- **GekoWidgets/AppIntent.swift**: Simplified to ConfigurationAppIntent only; uses shared intents from GekoShared

## Manual Testing

### App Shortcuts
1. Build and run the app on a device or simulator
2. Open the **Shortcuts** app
3. Verify "Complete Habit" and "Toggle Habit" appear under Geko
4. Run a shortcut and confirm the habit is completed in Geko
5. Verify widgets refresh after completion

### Siri (device recommended)
- Say: "Hey Siri, complete [habit name] in Geko"
- Confirm the habit is completed

### URL Scheme
1. In Safari, enter: `geko://complete?habit=Exercise` (use an existing habit name)
2. Confirm the app opens and the habit is completed
3. Try `geko://toggle?habit=Exercise` to toggle completion

### x-callback-url (optional)
- Use `geko://x-callback-url/complete?habit=Exercise&x-success=...` from another app to test callback on success

Made with [Cursor](https://cursor.com)